### PR TITLE
[ASN-135] Fix: 숏폼 영상 정지 버그, 북마크 라우팅 버그 수정

### DIFF
--- a/apps/service/next.config.ts
+++ b/apps/service/next.config.ts
@@ -10,6 +10,15 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        // /stream/** 요청을 stream.asinna.store로 프록시 (CORS 우회)
+        source: '/stream/:path*',
+        destination: 'https://stream.asinna.store/:path*',
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/service/src/app/(blank)/long/page.tsx
+++ b/apps/service/src/app/(blank)/long/page.tsx
@@ -2,8 +2,6 @@ import { LongFormVideoData } from '@/types/video';
 import { VideoInfo } from './_components/VideoInfo';
 import { VideoPlayer } from './_components/VideoPlayer';
 import RecommendedSection from '@/app/(all)/home/_components/RecommendedSection';
-import { LeftArrow } from '@repo/ui';
-import { PageHeader } from './_components/PageHeader';
 
 const metadata: LongFormVideoData = {
   videoId: 's1',
@@ -32,7 +30,7 @@ export default function LongPage() {
     <div className="flex h-screen flex-col">
       <div className="flex-none shrink-0">
         <VideoPlayer
-          src={metadata.videoUrl}
+          src={metadata.videoUrl || ''}
           thumbnail={metadata.thumbnail ?? undefined}
         />
       </div>

--- a/apps/service/src/app/(blank)/shorts/_components/ShortsTab.tsx
+++ b/apps/service/src/app/(blank)/shorts/_components/ShortsTab.tsx
@@ -17,6 +17,7 @@ import {
   mapVideoDetailToShortsData,
   mapRecommendationToShortsData,
 } from '@/utils/videoMapper';
+import { LoadingSpinner } from '@/components/LoadingSpinner';
 
 export interface ShortsTabProps {
   params: { v?: string; listType?: string };
@@ -89,14 +90,22 @@ export default function ShortsTab({ params }: ShortsTabProps) {
           mapRecommendationToShortsData,
         );
 
-    // 단건 데이터가 존재하면 배열 맨 앞에 꽂고, 무한스크롤 데이터 중 중복 항목 제거
     if (targetVideoId && detailData) {
       const formattedDetail = mapVideoDetailToShortsData(detailData);
 
-      formattedVideos = [
-        formattedDetail,
-        ...formattedVideos.filter((v) => v.videoId !== String(targetVideoId)),
-      ];
+      // 타겟 영상이 이미 리스트에 존재하는지 확인 (예: 북마크 리스트에서 클릭해 들어온 경우)
+      const existingIndex = formattedVideos.findIndex(
+        (v) => String(v.videoId) === String(targetVideoId),
+      );
+
+      if (existingIndex === -1) {
+        // 리스트에 없다면 (외부 링크 진입 등) 어쩔 수 없이 맨 앞에 꽂습니다.
+        formattedVideos = [formattedDetail, ...formattedVideos];
+      } else {
+        // 리스트에 이미 존재한다면 (북마크 리스트에서 클릭해 들어온 경우)
+        // 순서는 그대로 냅두고, 데이터만 상세 데이터로 덮어씌워 줍니다!
+        formattedVideos[existingIndex] = formattedDetail;
+      }
     }
 
     return formattedVideos;
@@ -108,15 +117,18 @@ export default function ShortsTab({ params }: ShortsTabProps) {
     detailData,
   ]);
 
+  const isDetailLoading = targetVideoId && !detailData;
+
+  if (isDetailLoading) {
+    // 공통 로딩 스피너 컴포넌트나 스켈레톤 UI를 반환
+    return <LoadingSpinner thumbnail={''} />;
+  }
+
+  // 데이터가 완벽하게 준비된 이후에만 BaseShortsTab 렌더링
   return (
-    <>
-      {(isLoading || detailLoading) && <div>로딩중...</div>}
-      <BaseShortsTab
-        algorithmList={videos}
-        onRequireMoreVertical={() => {
-          if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-        }}
-      />
-    </>
+    <BaseShortsTab
+      algorithmList={videos}
+      onRequireMoreVertical={hasNextPage ? fetchNextPage : undefined}
+    />
   );
 }

--- a/apps/service/src/components/LoadingSpinner.tsx
+++ b/apps/service/src/components/LoadingSpinner.tsx
@@ -1,8 +1,20 @@
 export const LoadingSpinner = ({ thumbnail }: { thumbnail: string }) => {
   return (
-    <div className="relative flex h-dvh w-full items-center justify-center bg-black">
-      <img src={thumbnail} alt="thumbnail" />
-      <svg className="h-10 w-10 animate-spin text-white" viewBox="0 0 24 24">
+    <div className="relative flex h-dvh w-full items-center justify-center overflow-hidden bg-black">
+      {/* 배경 썸네일 */}
+      {thumbnail && (
+        <img
+          src={thumbnail}
+          alt="thumbnail"
+          className="absolute inset-0 h-full w-full object-cover opacity-50"
+        />
+      )}
+
+      {/* 로딩 스피너 (z-10으로 맨 위로 올림) */}
+      <svg
+        className="relative z-10 h-10 w-10 animate-spin text-white"
+        viewBox="0 0 24 24"
+      >
         <circle
           className="opacity-25"
           cx="12"

--- a/apps/service/src/components/shortForm/BaseShortsTab.tsx
+++ b/apps/service/src/components/shortForm/BaseShortsTab.tsx
@@ -232,7 +232,11 @@ export default function BaseShortsTab({
     isPending: isS3Pending,
     isError: isS3Error,
   } = useVideoS3Url(currentVideo?.videoId);
-  const s3Url = s3Data?.masterUrl;
+  const rawS3Url = s3Data?.masterUrl;
+  // stream.asinna.store를 /stream/ 프록시로 치환 → CORS 우회 (next.config.ts rewrites)
+  const s3Url = rawS3Url
+    ? rawS3Url.replace('https://stream.asinna.store', '/stream')
+    : undefined;
 
   const { mutate: updatePosition } = useUpdateWatchPosition(
     currentVideo ? Number(currentVideo.videoId) : 0,

--- a/apps/service/src/components/shortForm/BaseShortsTab.tsx
+++ b/apps/service/src/components/shortForm/BaseShortsTab.tsx
@@ -234,9 +234,10 @@ export default function BaseShortsTab({
   } = useVideoS3Url(currentVideo?.videoId);
   const rawS3Url = s3Data?.masterUrl;
   // stream.asinna.store를 /stream/ 프록시로 치환 → CORS 우회 (next.config.ts rewrites)
-  const s3Url = rawS3Url
-    ? rawS3Url.replace('https://stream.asinna.store', '/stream')
-    : undefined;
+  const s3Url =
+    process.env.NODE_ENV === 'development'
+      ? rawS3Url?.replace(process.env.NEXT_PUBLIC_STREAM_DOMAIN!, '/stream')
+      : rawS3Url;
 
   const { mutate: updatePosition } = useUpdateWatchPosition(
     currentVideo ? Number(currentVideo.videoId) : 0,

--- a/apps/service/src/components/shortForm/BaseShortsTab.tsx
+++ b/apps/service/src/components/shortForm/BaseShortsTab.tsx
@@ -47,15 +47,25 @@ export default function BaseShortsTab({
   algorithmList,
   onRequireMoreVertical,
 }: BaseShortsTabProps) {
-  const [vList, setVList] = useState<ShortFormVideoData[]>(algorithmList);
-  const lastAlgorithmLengthRef = useRef(algorithmList.length);
-  const [rowIndex, setRowIndex] = useState(0);
-  const [colIndex, setColIndex] = useState(0);
-  const [hList, setHList] = useState<ShortFormVideoData[]>([]);
-
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  const [vList, setVList] = useState<ShortFormVideoData[]>(algorithmList);
+  const lastAlgorithmLengthRef = useRef(algorithmList.length);
+  const [rowIndex, setRowIndex] = useState(() => {
+    const targetId = searchParams.get('v');
+    if (!targetId) return 0; // 파라미터가 없으면 0층부터
+
+    const targetIndex = algorithmList.findIndex(
+      (video) => String(video.videoId) === targetId,
+    );
+
+    // 리스트에서 타겟 영상을 찾으면 그 층수부터, 못 찾으면 0층부터 시작
+    return targetIndex !== -1 ? targetIndex : 0;
+  });
+  const [colIndex, setColIndex] = useState(0);
+  const [hList, setHList] = useState<ShortFormVideoData[]>([]);
 
   const isLogin = useIsLoggedIn();
   const queryClient = useQueryClient();

--- a/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
+++ b/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
@@ -27,12 +27,15 @@ export interface VirtualSwipePlayerProps {
 export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
   const playerRef = useRef<HTMLVideoElement | null>(null);
   const currentTimeRef = useRef<number>(0);
-  const [isPlaying, setIsPlaying] = useState(true);
   const isLogin = useIsLoggedIn();
-  // videoId가 바뀔 때만 재생 상태 초기화 (객체/URL 참조 변경에 의한 중복 실행 방지)
-  useEffect(() => {
-    setIsPlaying(true);
-  }, [props.currentVideo.videoId]);
+  // 현재 재생 중인 videoId 저장.
+  const [playingVideoId, setPlayingVideoId] = useState<string | null>(null);
+
+  // 렌더링 시점에 즉시 평가 (새 영상으로 넘어가면 즉각 false가 됨)
+  const isPlaying = playingVideoId === props.currentVideo.videoId;
+
+  // 어떤 비디오가 초기화(seekTo)를 마쳤는지 ID로 저장
+  const initializedVideoIdRef = useRef<string | null>(null);
 
   // 최신 onStopWatching 콜백 참조 유지
   const latestStopWatchingRef = useRef(props.onStopWatching);
@@ -133,7 +136,9 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
 
     if (distance < 10 && timeElapsed < 400) {
       // 짧은 터치 로직
-      setIsPlaying((prev) => !prev);
+      setPlayingVideoId((prev) =>
+        prev === props.currentVideo.videoId ? null : props.currentVideo.videoId,
+      );
       return;
     }
 
@@ -194,14 +199,16 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
             <ReactPlayer
               key={`player-${props.currentVideo.videoId}`}
               onReady={() => {
-                // URL이 준비되면 시청 위치로 이동
-                if (playerRef.current && props.watchProgress) {
-                  playerRef.current.currentTime = props.watchProgress;
+                if (
+                  initializedVideoIdRef.current !== props.currentVideo.videoId
+                ) {
+                  setPlayingVideoId(props.currentVideo.videoId); // 재생 시작
+                  initializedVideoIdRef.current = props.currentVideo.videoId; // 현재 영상 ID 기억
                 }
               }}
               ref={playerRef}
               src={props.videoUrl}
-              playing={isPlaying && !!props.videoUrl}
+              playing={isPlaying}
               muted={false}
               controls={false}
               loop
@@ -210,7 +217,6 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
               height="100%"
               style={{ objectFit: 'cover' }}
               onPlay={() => {
-                setIsPlaying(true);
                 if (!isLogin) return;
                 if (
                   props.onStartWatching &&
@@ -225,7 +231,11 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
                   currentTimeRef.current = playerRef.current.currentTime;
                 }
               }}
-              onPause={() => setIsPlaying(false)}
+              onPause={() => {
+                if (playingVideoId === props.currentVideo.videoId) {
+                  setPlayingVideoId(null);
+                }
+              }}
             />
           )}
 

--- a/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
+++ b/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
@@ -55,7 +55,17 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
         );
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.currentVideo.videoId]);
+
+  // 영상 자동 재생
+  useEffect(() => {
+    // 100ms 뒤에 재생 시작. 영상이 완전히 로드되기 전에 seekTo가 호출되는 것을 방지하기 위함.
+    const starterTimer = setTimeout(() => {
+      setPlayingVideoId(props.currentVideo.videoId);
+    }, 100);
+
+    // 빠르게 스와이프해서 넘어갈 경우 타이머 취소 (에러 방지)
+    return () => clearTimeout(starterTimer);
   }, [props.currentVideo.videoId]);
 
   // 10초마다 시청 위치 업데이트 (onWatchProgressUpdate 프롭이 제공됐을 때만 실행)
@@ -202,7 +212,6 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
                 if (
                   initializedVideoIdRef.current !== props.currentVideo.videoId
                 ) {
-                  setPlayingVideoId(props.currentVideo.videoId); // 재생 시작
                   initializedVideoIdRef.current = props.currentVideo.videoId; // 현재 영상 ID 기억
                 }
               }}

--- a/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
+++ b/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
@@ -3,7 +3,6 @@ import ReactPlayer from 'react-player';
 import { useRef, useState, ReactNode, useEffect } from 'react';
 import { ShortFormVideoData } from '@/types/video';
 import { useIsLoggedIn } from '@/store/useAuthStore';
-import { LoadingSpinner } from '../LoadingSpinner';
 export interface VirtualSwipePlayerProps {
   currentVideo: ShortFormVideoData;
   upVideo: ShortFormVideoData | null;
@@ -27,12 +26,13 @@ export interface VirtualSwipePlayerProps {
 
 export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
   const playerRef = useRef<HTMLVideoElement | null>(null);
+  const currentTimeRef = useRef<number>(0);
   const [isPlaying, setIsPlaying] = useState(true);
   const isLogin = useIsLoggedIn();
-  // 로딩 상태나 URL이 바뀌면 플레이 상태 초기화
+  // videoId가 바뀔 때만 재생 상태 초기화 (객체/URL 참조 변경에 의한 중복 실행 방지)
   useEffect(() => {
     setIsPlaying(true);
-  }, [props.currentVideo, props.videoUrl, props.videoLoading]);
+  }, [props.currentVideo.videoId]);
 
   // 최신 onStopWatching 콜백 참조 유지
   const latestStopWatchingRef = useRef(props.onStopWatching);
@@ -43,9 +43,9 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
   // 영상을 벗어날 때 (currentVideo 변경 또는 언마운트)
   useEffect(() => {
     return () => {
-      // 컴포넌트 언마운트 시점에 playerRef.current가 유효한지 안전하게 검사
-      if (latestStopWatchingRef.current && playerRef.current) {
-        let currentTime = playerRef.current.currentTime || 0;
+      // unmount 시 playerRef.current는 이미 null이 되므로 currentTimeRef를 사용
+      if (latestStopWatchingRef.current) {
+        const currentTime = currentTimeRef.current;
         latestStopWatchingRef.current(
           Number(props.currentVideo.videoId),
           Math.floor(currentTime),
@@ -70,6 +70,7 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
       if (playerRef.current) {
         const currentTime = playerRef.current.currentTime;
         if (currentTime !== undefined) {
+          currentTimeRef.current = currentTime; // unmount cleanup을 위해 캐싱
           props.onWatchProgressUpdate?.(Math.floor(currentTime));
         }
       }
@@ -200,7 +201,7 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
               }}
               ref={playerRef}
               src={props.videoUrl}
-              playing={isPlaying}
+              playing={isPlaying && !!props.videoUrl}
               muted={false}
               controls={false}
               loop
@@ -216,6 +217,12 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
                   playerRef.current?.currentTime === 0
                 ) {
                   props.onStartWatching(Number(props.currentVideo.videoId));
+                }
+              }}
+              onTimeUpdate={() => {
+                // currentTimeRef를 항상 최신 시청 위치로 유지 (unmount cleanup에서 사용)
+                if (playerRef.current) {
+                  currentTimeRef.current = playerRef.current.currentTime;
                 }
               }}
               onPause={() => setIsPlaying(false)}

--- a/apps/service/src/types/video.ts
+++ b/apps/service/src/types/video.ts
@@ -1,6 +1,6 @@
 export interface VideoData {
   videoId: string;
-  videoUrl: string;
+  videoUrl?: string;
   thumbnail: string;
   uploader: { name: string; profileImg: string | null };
   title: string;


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- 숏폼 영상 정지 이슈 해결
- 북마크 라우팅 버그 수정

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할  코드, 설정, 구조의 변경을 명시 -->
- 숏폼 프리징 이슈
  플레이어와 브라우저가 서로 영상 준비와 재생 명령을 기다리며 첫 화면이 멈추는 무한 대기 문제가 있었습니다.
  이를 해결하기 위해 새 영상을 우선 정지 상태로 띄워 스와이프 에러를 방지하고,
  렌더링 0.1초 뒤에 선제적으로 재생 상태로 전환하는 타이머를 추가하여 멈춤 현상을 해결했습니다.

- 북마크 라우팅 버그는, 영상 리스트를 받아오고 항상 index를 0으로 작성해두었던 문제였습니다. 이를 map 함수를 통해 인덱스를 찾아내어 해결했습니다.

<br/>

## 🎫 Jira Ticket
- Jira Ticket: ASN-135

<br/>

## #️⃣관련 이슈

- closes #50 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 스트리밍 경로에 대한 CORS 프록시 지원 추가
  * 비디오 상세 로드 시 전용 로딩 스피너 표시
  * URL 기반 비디오 재생 위치 복원 지원

* **버그 수정**
  * 비디오 URL이 없을 때의 처리 개선
  * 언마운트 시 재생 진행 상황 정확히 저장되도록 개선

* **리팩토링**
  * 비디오 재생 상태 관리 및 자동 재생 로직 개선
  * 라우팅/URL 기반 초기화와 미디어 URL 처리 정리
  * 로딩 스피너의 레이어링 및 표시 방식 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->