### PR TITLE
[ASN-168] Fix: Video play 에러

### DIFF
--- a/apps/service/next.config.ts
+++ b/apps/service/next.config.ts
@@ -17,6 +17,11 @@ const nextConfig: NextConfig = {
         source: '/stream/:path*',
         destination: 'https://stream.asinna.store/:path*',
       },
+      {
+        // /gcs-proxy/** 요청을 commondatastorage.googleapis.com으로 프록시 (CORS 우회)
+        source: '/gcs-proxy/:path*',
+        destination: 'https://commondatastorage.googleapis.com/:path*',
+      },
     ];
   },
   images: {

--- a/apps/service/src/app/(blank)/onBoarding/_components/shorts/tour/ShortsTourTab.tsx
+++ b/apps/service/src/app/(blank)/onBoarding/_components/shorts/tour/ShortsTourTab.tsx
@@ -17,8 +17,7 @@ export interface ShortsTourTabProps {
 const ONBOARDING_DATA: ShortFormVideoData[] = [
   {
     videoId: 'ob-1',
-    videoUrl:
-      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
+    videoUrl: '/gcs-proxy/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
     thumbnail: '',
     uploader: { name: '어른나라', profileImg: null },
     title: '온보딩 첫번째 영상',
@@ -31,8 +30,7 @@ const ONBOARDING_DATA: ShortFormVideoData[] = [
   },
   {
     videoId: 'ob-2',
-    videoUrl:
-      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4',
+    videoUrl: '/gcs-proxy/gtv-videos-bucket/sample/ForBiggerFun.mp4',
     thumbnail: '',
     uploader: { name: '어른나라', profileImg: null },
     title: '온보딩 두번째 영상',
@@ -45,8 +43,7 @@ const ONBOARDING_DATA: ShortFormVideoData[] = [
   },
   {
     videoId: 'ob-3',
-    videoUrl:
-      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
+    videoUrl: '/gcs-proxy/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
     thumbnail: '',
     uploader: { name: '어른나라', profileImg: null },
     title: '온보딩 세번째 영상',

--- a/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
+++ b/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
@@ -4,6 +4,7 @@ import { ShortFormVideoData } from '@/types/video';
 import { useIsLoggedIn } from '@/store/useAuthStore';
 import { AdProgressBar } from '@/app/(blank)/long/_components/AdProgressBar';
 import { toast } from '@/lib/toast';
+import { useHlsPlayer } from '@/hooks/useHlsPlayer';
 
 const SHORT_FORM_PLAYER_STYLE = `
   .shortform-player video {
@@ -46,6 +47,8 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
   /* --- 비디오 제어 및 시청 기록 로직 --- */
   const videoRef = useRef<HTMLVideoElement>(null);
   const currentTimeRef = useRef<number>(0);
+
+  useHlsPlayer(videoRef, props.videoUrl ?? null);
   const isLogin = useIsLoggedIn();
 
   // play() Promise 추적 - pause() 호출 전 반드시 resolve 대기
@@ -277,9 +280,8 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
         <div className="shortform-player absolute inset-0 h-full w-full">
           {props.videoUrl ? (
             <video
-              key={props.currentVideo.videoId}
               ref={videoRef}
-              src={props.videoUrl}
+              poster={props.getThumbnailUrl(props.currentVideo) || undefined}
               playsInline
               muted={false}
               controls={false}

--- a/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
+++ b/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
@@ -1,19 +1,15 @@
 'use client';
-import ReactPlayer from 'react-player';
 import { useRef, useState, ReactNode, useEffect, useCallback } from 'react';
 import { ShortFormVideoData } from '@/types/video';
 import { useIsLoggedIn } from '@/store/useAuthStore';
 import { AdProgressBar } from '@/app/(blank)/long/_components/AdProgressBar';
 import { toast } from '@/lib/toast';
-import { Button } from '@repo/ui';
 
 const SHORT_FORM_PLAYER_STYLE = `
-  .shortform-player {
-    --media-object-fit: cover !important;
-  }
-  .shortform-player :where(video, [part="video"], media-video, canvas) {
+  .shortform-player video {
     object-fit: cover !important;
-    max-width: none !important;
+    width: 100% !important;
+    height: 100% !important;
   }
 `;
 
@@ -48,12 +44,19 @@ export interface VirtualSwipePlayerProps {
 
 export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
   /* --- 비디오 제어 및 시청 기록 로직 --- */
-  const playerRef = useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const currentTimeRef = useRef<number>(0);
   const isLogin = useIsLoggedIn();
-  const [playingVideoId, setPlayingVideoId] = useState<string | null>(null);
-  const isPlaying = playingVideoId === props.currentVideo.videoId;
-  const initializedVideoIdRef = useRef<string | null>(null);
+
+  // play() Promise 추적 - pause() 호출 전 반드시 resolve 대기
+  const playPromiseRef = useRef<Promise<void> | null>(null);
+
+  // 실제 재생 상태 (브라우저 이벤트 기준)
+  const [isActuallyPlaying, setIsActuallyPlaying] = useState(false);
+
+  // 사용자가 수동으로 일시정지했는지 여부 (canplay 시 자동재생 여부 결정)
+  const isUserPausedRef = useRef(false);
+
   const latestStopWatchingRef = useRef(props.onStopWatching);
   const latestProgressUpdateRef = useRef(props.onWatchProgressUpdate);
   const lastReportedTimeRef = useRef<number>(Date.now());
@@ -79,12 +82,19 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
     }
   }, [props.currentVideo.videoId, isLogin]);
 
+  // 영상 변경 시 상태 초기화
+  useEffect(() => {
+    isUserPausedRef.current = false;
+    setIsActuallyPlaying(false);
+    playPromiseRef.current = null;
+  }, [props.currentVideo.videoId]);
+
   // 벗어날 때 기록 저장
   useEffect(() => {
     return () => {
-      if (latestStopWatchingRef.current && playerRef.current) {
+      if (latestStopWatchingRef.current && videoRef.current) {
         const finalTime =
-          playerRef.current.currentTime ?? currentTimeRef.current;
+          videoRef.current.currentTime ?? currentTimeRef.current;
         latestStopWatchingRef.current(
           props.currentVideo.videoId,
           Math.floor(finalTime),
@@ -94,23 +104,19 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
     };
   }, [props.currentVideo.videoId]);
 
-  // 자동 재생 타이머
-  useEffect(() => {
-    const starterTimer = setTimeout(
-      () => setPlayingVideoId(props.currentVideo.videoId),
-      100,
-    );
-    return () => clearTimeout(starterTimer);
-  }, [props.currentVideo.videoId]);
-
   // 10초마다 주기적 업데이트
   useEffect(() => {
-    if (!isPlaying || props.videoLoading || !isLogin || props.currentVideo.isAd)
+    if (
+      !isActuallyPlaying ||
+      props.videoLoading ||
+      !isLogin ||
+      props.currentVideo.isAd
+    )
       return;
 
     const interval = setInterval(() => {
-      if (playerRef.current && latestProgressUpdateRef.current) {
-        const currentTime = playerRef.current.currentTime || 0;
+      if (videoRef.current && latestProgressUpdateRef.current) {
+        const currentTime = videoRef.current.currentTime || 0;
         currentTimeRef.current = currentTime;
         latestProgressUpdateRef.current(
           Math.floor(currentTime),
@@ -119,7 +125,46 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
       }
     }, 10000);
     return () => clearInterval(interval);
-  }, [isPlaying, props.videoLoading, props.currentVideo.videoId, isLogin]);
+  }, [
+    isActuallyPlaying,
+    props.videoLoading,
+    props.currentVideo.videoId,
+    isLogin,
+  ]);
+
+  // canplay: 영상 재생 준비 완료. 사용자가 일시정지하지 않은 경우 자동재생
+  const handleCanPlay = useCallback(() => {
+    if (isUserPausedRef.current) return;
+    const video = videoRef.current;
+    if (!video) return;
+    playPromiseRef.current = video.play();
+    playPromiseRef.current?.catch(() => {
+      // 브라우저 정책으로 차단된 경우 실제 상태를 false로
+      setIsActuallyPlaying(false);
+    });
+  }, []);
+
+  // 클릭 토글용 play/pause (play Promise 레이스 컨디션 방지)
+  const togglePlayPause = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (isActuallyPlaying) {
+      isUserPausedRef.current = true;
+      if (playPromiseRef.current) {
+        playPromiseRef.current.then(() => video.pause()).catch(() => {});
+        playPromiseRef.current = null;
+      } else {
+        video.pause();
+      }
+    } else {
+      isUserPausedRef.current = false;
+      playPromiseRef.current = video.play();
+      playPromiseRef.current?.catch(() => {
+        setIsActuallyPlaying(false);
+      });
+    }
+  }, [isActuallyPlaying]);
 
   /* 통합 포인터(터치/마우스) 스와이프 로직 */
   const [offset, setOffset] = useState({ x: 0, y: 0 });
@@ -171,9 +216,7 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
 
     // 1. 단순 클릭/터치 판정
     if (distance < 10 && timeElapsed < 300) {
-      setPlayingVideoId((prev) =>
-        prev === props.currentVideo.videoId ? null : props.currentVideo.videoId,
-      );
+      togglePlayPause();
       setOffset({ x: 0, y: 0 });
       return;
     }
@@ -213,7 +256,7 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       // 컨테이너 밖으로 나갔을 때의 안전장치
-      onPointerLeave={(e) => {
+      onPointerLeave={() => {
         if (isDragging.current) {
           isDragging.current = false;
           setOffset({ x: 0, y: 0 });
@@ -221,7 +264,6 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
       }}
       // 드래그 시 이미지/텍스트 선택 방지
       onDragStart={(e) => e.preventDefault()}
-      // 인라인 스타일로 오프셋 적용
     >
       <style>{SHORT_FORM_PLAYER_STYLE}</style>
       <div
@@ -232,30 +274,20 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
         }}
       >
         {/* 중앙 플레이어 */}
-        <div className="absolute inset-0 h-full w-full">
+        <div className="shortform-player absolute inset-0 h-full w-full">
           {props.videoUrl ? (
-            <ReactPlayer
-              className="shortform-player"
+            <video
               key={props.currentVideo.videoId}
-              onReady={() => {
-                if (
-                  initializedVideoIdRef.current !== props.currentVideo.videoId
-                ) {
-                  initializedVideoIdRef.current = props.currentVideo.videoId; // 현재 영상 ID 기억
-                }
-              }}
-              ref={playerRef}
+              ref={videoRef}
               src={props.videoUrl}
-              playing={isPlaying}
+              playsInline
               muted={false}
               controls={false}
-              playsInline
-              width="100%"
-              height="100%"
-              style={{ objectFit: 'cover' }}
+              onCanPlay={handleCanPlay}
               onPlay={() => {
+                setIsActuallyPlaying(true);
                 if (!isLogin) return;
-                const currentTime = playerRef.current?.currentTime || 0;
+                const currentTime = videoRef.current?.currentTime || 0;
                 if (props.onStartWatching && currentTime < 1) {
                   props.onStartWatching(
                     props.currentVideo.videoId,
@@ -263,7 +295,9 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
                   );
                 }
               }}
+              onPause={() => setIsActuallyPlaying(false)}
               onEnded={() => {
+                setIsActuallyPlaying(false);
                 if (isLogin) {
                   props.onStopWatching?.(
                     props.currentVideo.videoId,
@@ -275,8 +309,9 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
                   }
                 }
                 // 처음으로 돌리기
-                if (playerRef.current) playerRef.current.currentTime = 0;
+                if (videoRef.current) videoRef.current.currentTime = 0;
               }}
+              style={{ objectFit: 'cover', width: '100%', height: '100%' }}
             />
           ) : props.videoError ? (
             <div className="flex h-dvh w-full flex-col items-center justify-center bg-black p-4 text-center text-white">
@@ -288,14 +323,14 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
           {props.currentVideo.isAd && (
             <div className="pointer-events-none absolute bottom-0 left-0 z-50 w-full p-1">
               <AdProgressBar
-                playerRef={playerRef}
+                playerRef={videoRef}
                 duration={props.currentVideo.duration}
               />
             </div>
           )}
         </div>
 
-        {!isPlaying && !props.videoLoading && (
+        {!isActuallyPlaying && !props.videoLoading && (
           <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-black/20">
             <svg
               width="72"


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- ReactPlayer -> video 태그로 변경
- 프록시 설정

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할  코드, 설정, 구조의 변경을 명시 -->
- 프록시 설정은 추후에 제거할 예정입니다.
- 이전에 고려했던 video 태그로 변경했습니다.
이전에는 자동 화질 전환 기능을 활용하기 위해 React Player를 사용했습니다.커스텀 화질 조절이 필요해서 React Player를 필요성이 줄어들었습니다. 또한 play Promise의 레이싱 문제가 있었습니다. 이는 자동으로 바로 재생되는 곳에서 발생하는 문제였습니다. 브라우저의 정책상 화면이 전환되자마자 영상이 재생되기 위해서는 muted 상태이거나, 제스처를 통해 페이지로 이동하고 1-2초 이내에 영상 로딩이 완료되어야합니다. 1초 후에 영상이 재생되지 않는 문제를 우회하기 위해 setInterval로 재생을 반복 시도하는 과정에서, play() Promise가 pending 상태일 때 또 다른 호출이 끼어드는 레이싱 문제가 발생했습니다. 이를 onCanPlay 이벤트 기반으로 교체하고, play() Promise를 직접 추적하여 해결했습니다.
- setTimeout(100ms)로 재생 트리거 → 브라우저 gesture chain 끊김 → play() 차단
- play() Promise가 pending인데 pause() 호출 → "interrupted by pause" 에러

이러한 문제로 영상이 실제로 준비되었을 때, play되도록 수정을 해야했으나, 이를 위해서는 video의 onCanPlay 옵션을 사용해야했습니다.
<br/>

## 🎫 Jira Ticket
- Jira Ticket: ASN-168

<br/>

## #️⃣관련 이슈

- closes #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 비디오 플레이어를 네이티브 구현으로 최적화하여 재생 안정성 및 성능 향상
  * 온보딩 비디오를 로컬 프록시 경로로 변경하여 로딩 속도 개선
  * 콘텐츠 전송 프록시 규칙 추가로 미디어 배포 효율성 증대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->