### PR TITLE
[ASN-168] Fix: 숏폼탭 정지 문제 및 슬라이딩 윈도우 수정

### DIFF
--- a/apps/service/src/components/shortForm/BaseShortsTab.tsx
+++ b/apps/service/src/components/shortForm/BaseShortsTab.tsx
@@ -30,24 +30,11 @@ import {
 } from '@/lib/tanstack/mutation/watch-history.mutation';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { useIsLoggedIn } from '@/store/useAuthStore';
-import { Button } from '@repo/ui';
 
-// 무한 스크롤 메모리 초과 방지, window 형식. offset 보정 함수.
-function applyWindowing<T>(
-  prevList: T[],
-  newItemsToAdd: T[],
-  windowSize: number,
-  currentIndex: number,
-  setIndexOffset: React.Dispatch<React.SetStateAction<number>>,
-  minBuffer: number = 15,
-): T[] {
-  const appended = [...prevList, ...newItemsToAdd];
-  if (appended.length <= windowSize) return appended;
-
-  const cutSize = appended.length - windowSize;
-  setIndexOffset((prevIndex) => Math.max(0, prevIndex - cutSize));
-  return appended.slice(cutSize);
-}
+// 슬라이딩 윈도우 상수
+const MAX_BACK_BUFFER = 10; // 현재 위치 뒤로 유지할 최대 개수
+const WINDOW_SIZE = 30; // 메모리에 담아둘 최대 개수
+const PREFETCH_THRESHOLD = 15; // 앞으로 남은 영상이 이 이하이면 다음 페이지 요청
 
 interface BaseShortsTabProps {
   algorithmList: ShortFormVideoData[];
@@ -83,9 +70,7 @@ export default function BaseShortsTab({
   const isLogin = useIsLoggedIn();
   const queryClient = useQueryClient();
 
-  // 페이징
   const FETCH_SIZE = 10; // api에 요청하는 개수
-  const WINDOW_SIZE = 20; // 메모리에 담아둘 최대 개수
 
   useEffect(() => {
     // api로 algorithmList를 성공적으로 추가한 경우
@@ -94,19 +79,18 @@ export default function BaseShortsTab({
       lastAlgorithmLengthRef.current = algorithmList.length;
 
       setVList((prev) => {
-        // 처음 리스트를 받아온 경우
         if (prev.length === 0) return algorithmList;
 
-        // 기존 리스트 뒤에 다음 페이지 영상 리스트가 추가된 경우
         const newItems = algorithmList.slice(-addedCount);
-        return applyWindowing(
-          prev,
-          newItems,
-          WINDOW_SIZE,
-          colIndex,
-          setRowIndex,
-          10,
-        );
+        const appended = [...prev, ...newItems];
+
+        // WINDOW_SIZE 초과 시 앞에서 제거 (안전장치 — 평소엔 handleSwipe에서 관리)
+        if (appended.length > WINDOW_SIZE) {
+          const excess = appended.length - WINDOW_SIZE;
+          setRowIndex((r) => Math.max(0, r - excess));
+          return appended.slice(excess);
+        }
+        return appended;
       });
     }
   }, [algorithmList]);
@@ -163,21 +147,18 @@ export default function BaseShortsTab({
       const addedCount = allRelated.length - lastRelatedLengthRef.current;
       lastRelatedLengthRef.current = allRelated.length;
 
-      // hList 업데이트
       setHList((prev) => {
-        // 처음 리스트를 받아온 경우
         if (prev.length === 0) return [source, ...allRelated];
 
-        // 기존 리스트 뒤에 다음 페이지 영상 리스트가 추가된 경우
         const newItems = allRelated.slice(-addedCount);
-        return applyWindowing(
-          prev,
-          newItems,
-          WINDOW_SIZE,
-          colIndex,
-          setColIndex,
-          10,
-        );
+        const appended = [...prev, ...newItems];
+
+        if (appended.length > WINDOW_SIZE) {
+          const excess = appended.length - WINDOW_SIZE;
+          setColIndex((c) => Math.max(0, c - excess));
+          return appended.slice(excess);
+        }
+        return appended;
       });
     } else if (
       lastRelatedLengthRef.current === 0 &&
@@ -245,20 +226,40 @@ export default function BaseShortsTab({
 
   // VirtualSwipePlayer이 스와이프 완료를 알려주면 상태 업데이트
   const handleSwipe = (direction: 'up' | 'down' | 'left' | 'right') => {
-    if (direction === 'up' || direction === 'down') {
-      const nextRow = direction === 'down' ? rowIndex + 1 : rowIndex - 1;
-      sourceVideoIdRef.current = vList[nextRow]?.videoId;
-      fetchNextPage();
+    if (direction === 'down') {
+      // 가로 영상 보던 중이었다면 vList 해당 행 복원
+      let baseList = vList;
+      if (colIndex !== 0) {
+        baseList = [...vList];
+        baseList[rowIndex] = hList[colIndex];
+      }
 
-      if (
-        direction === 'down' &&
-        nextRow >= vList.length - FETCH_SIZE &&
-        onRequireMoreVertical
-      ) {
+      let newList = baseList;
+      let newRowIndex = rowIndex + 1;
+
+      // 슬라이딩 윈도우: 뒤 버퍼가 MAX_BACK_BUFFER를 초과하면 앞에서 1개 제거
+      // index는 그대로 MAX_BACK_BUFFER로 유지 (리스트가 앞으로 당겨짐)
+      if (rowIndex >= MAX_BACK_BUFFER) {
+        newList = baseList.slice(1);
+        newRowIndex = rowIndex; // slice(1)로 인해 실질적으로 다음 영상을 가리킴
+      }
+
+      sourceVideoIdRef.current = newList[newRowIndex]?.videoId;
+
+      // 앞으로 남은 영상이 PREFETCH_THRESHOLD 이하이면 다음 페이지 미리 요청
+      const remaining = newList.length - newRowIndex - 1;
+      if (remaining <= PREFETCH_THRESHOLD && onRequireMoreVertical) {
         onRequireMoreVertical();
       }
 
-      // 위아래로 층을 떠날 때, 가로 영상을 보던 중이었다면 원본 덮어씌우기
+      setVList(newList);
+      fetchNextPage(); // 다음 행의 연관 영상 프리패치
+      startTransition(() => {
+        setRowIndex(newRowIndex);
+        setColIndex(0);
+      });
+    } else if (direction === 'up') {
+      // 가로 영상 보던 중이었다면 vList 해당 행 복원
       if (colIndex !== 0) {
         setVList((prev) => {
           const newList = [...prev];
@@ -267,9 +268,12 @@ export default function BaseShortsTab({
         });
       }
 
+      const newRowIndex = rowIndex - 1;
+      sourceVideoIdRef.current = vList[newRowIndex]?.videoId;
+      fetchNextPage();
       startTransition(() => {
-        setRowIndex(nextRow);
-        setColIndex(0); // 새 층에선 무조건 원본(0번)
+        setRowIndex(newRowIndex);
+        setColIndex(0);
       });
     } else if (direction === 'left') {
       startTransition(() => {

--- a/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
+++ b/apps/service/src/components/shortForm/VirtualSwipePlayer.tsx
@@ -148,11 +148,12 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
   }, []);
 
   // 클릭 토글용 play/pause (play Promise 레이스 컨디션 방지)
+  // isActuallyPlaying 대신 video.paused 기준으로 분기 — React 상태가 불일치해도 동작 보장
   const togglePlayPause = useCallback(() => {
     const video = videoRef.current;
     if (!video) return;
 
-    if (isActuallyPlaying) {
+    if (!video.paused) {
       isUserPausedRef.current = true;
       if (playPromiseRef.current) {
         playPromiseRef.current.then(() => video.pause()).catch(() => {});
@@ -167,7 +168,7 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
         setIsActuallyPlaying(false);
       });
     }
-  }, [isActuallyPlaying]);
+  }, []);
 
   /* 통합 포인터(터치/마우스) 스와이프 로직 */
   const [offset, setOffset] = useState({ x: 0, y: 0 });
@@ -298,6 +299,10 @@ export function VirtualSwipePlayer(props: VirtualSwipePlayerProps) {
                 }
               }}
               onPause={() => setIsActuallyPlaying(false)}
+              onTimeUpdate={() => {
+                
+                if (!isActuallyPlaying) setIsActuallyPlaying(true);
+              }}
               onEnded={() => {
                 setIsActuallyPlaying(false);
                 if (isLogin) {


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- 숏폼탭 정지 문제 해결
- 슬라이딩 윈도우 방식 수정

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할  코드, 설정, 구조의 변경을 명시 -->
- 숏폼탭 정지 문제
isActuallyPaying 상태와의 불일치로 인해 발생한 문제.
다음 영상으로 url이 교체될 때, 브라우저가 pause 이벤트를 발생시켜서 생기는 문제였습니다.
이 문제를 해겨라기 위해 , video.paused를 기준으로 분기 처리를 했습니다.

- 슬라이딩 윈도우 방식 수정
기존에 테스트를 위해서 20 size로 설정해두었습니다.
그러나 이 문제로 위의 영상을 받아오지 못하고, index 값을 기준으로 자르지 않고, 전체 크기를 기준으로 자르는 문제가 있어, fetch 기준으로 위의 영상이 정보가 10개 단위로 잘리는 문제가 발생했습니다.
기존의 index를 최대 값을 10으로 고정하고, 10개가 넘어갈 시, 앞에서 부터 영상을 자르는 형식으로 수정했습니다.

<br/>

## 🎫 Jira Ticket
- Jira Ticket: ASN-168

<br/>

## #️⃣관련 이슈

- closes #86 